### PR TITLE
Fix drop event with preventDefault

### DIFF
--- a/jquery.dragster.js
+++ b/jquery.dragster.js
@@ -34,6 +34,7 @@
                     event.preventDefault();
                 },
                 dragover: function (event) {
+                    $this.trigger('dragster:over', event);
                     event.preventDefault();
                 },
                 'dragster:enter': settings.enter,

--- a/jquery.dragster.js
+++ b/jquery.dragster.js
@@ -3,7 +3,8 @@
     $.fn.dragster = function (options) {
         var settings = $.extend({
             enter: $.noop,
-            leave: $.noop
+            leave: $.noop,
+            over: $.noop
         }, options);
 
         return this.each(function () {
@@ -12,26 +13,32 @@
                 $this = $(this);
 
             $this.on({
-                dragenter: function () {
+                dragenter: function (event) {
                     if (first) {
                         return second = true;
                     } else {
                         first = true;
-                        $this.trigger('dragster:enter');
+                        $this.trigger('dragster:enter', event);
                     }
-                }, 
-                dragleave: function () {
+                    event.preventDefault();
+                },
+                dragleave: function (event) {
                     if (second) {
                         second = false;
                     } else if (first) {
                         first = false;
                     }
                     if (!first && !second) {
-                        $this.trigger('dragster:leave');
+                        $this.trigger('dragster:leave', event);
                     }
+                    event.preventDefault();
+                },
+                dragover: function (event) {
+                    event.preventDefault();
                 },
                 'dragster:enter': settings.enter,
-                'dragster:leave': settings.leave
+                'dragster:leave': settings.leave,
+                'dragster:over': settings.over
             });
         });
     };


### PR DESCRIPTION
If preventDefault is not triggered, we can't use drop event. I fix it and added an over function to disable it by default.