### PR TITLE
Add bower compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "jquery-dragster",
+  "version": "0.0.1",
+  "homepage": "https://github.com/Teleborder/jquery-dragster",
+  "authors": [
+    "catmanjan",
+    "bensmithett"
+  ],
+  "description": "Unified drag and drop listener",
+  "main": "jquery.dragster.js",
+  "keywords": [
+    "jquery",
+    "dragster",
+    "dragenter",
+    "dragleave",
+    "drop"
+  ],
+  "license": "Unknown",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Add a bower file and a tag so that the bower registry can version the package.

Let me know if you would prefer a different versioning system - `0.0.1` was just to get something up.